### PR TITLE
Breaking change on run API

### DIFF
--- a/src/errors/RunRouteErrors.ts
+++ b/src/errors/RunRouteErrors.ts
@@ -57,7 +57,7 @@ export class MissingInputField extends RouteError {
     super({
       errorName: 'MissingInputField',
       message:
-        'Missing input field in the body: Format should be $runId: string. If there is no input string should be empty',
+        'Missing input field in the body: Format should be $input: [string or file]. If there is no input string should be empty',
       statusCode: 400,
     })
   }

--- a/src/routes/run/handlers.ts
+++ b/src/routes/run/handlers.ts
@@ -12,7 +12,7 @@ import {
   ReportNotReady,
   RunIdAlreadyExists,
 } from './../../errors/RunRouteErrors'
-import { BusboyLimits, FileInfo } from './../../typings.d'
+import { BusboyLimits, FileInfo, FieldToPersist } from './../../typings.d'
 
 const KILOBYTE = 1024
 const MEGABYTE = 1024 * KILOBYTE
@@ -48,7 +48,14 @@ export const parseInput = async (req: ReqWithRunArgs, res: Response, next: NextF
         fileSize: MAX_FILE_SIZE,
       }
 
-      const inputParser = new InputParser(req, { limits }, getInBasePath())
+      const partsToPersist: FieldToPersist[] = [
+        {
+          fieldname: 'input',
+          filename: req.params.runId,
+        },
+      ]
+
+      const inputParser = new InputParser(req, { limits }, getInBasePath(), partsToPersist)
       const inputFileArr = await inputParser.parse()
       Logger.info('[parseInput]', { inputFileArr: util.inspect(inputFileArr) })
       req.runArgs = await getRunInput(inputFileArr)

--- a/src/routes/run/index.ts
+++ b/src/routes/run/index.ts
@@ -3,6 +3,8 @@ import { Router } from 'express'
 
 export const runRoute = Router()
 
-runRoute.all('/', [parseInput, runHandler])
-runRoute.all('/:runId', [writeRunOnReq, statusHandler])
+runRoute.post('/:runId', [parseInput, runHandler])
+runRoute.get('/:runId', [writeRunOnReq, statusHandler])
+runRoute.delete('/:runId', [writeRunOnReq, statusHandler])
+
 runRoute.all('/:runId/result', [writeRunOnReq, resultHandler])

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -17,3 +17,8 @@ export interface FileInfo {
   path: string
   size: number
 }
+
+export interface FieldToPersist {
+  fieldname: string
+  filename: string
+}


### PR DESCRIPTION
- Modify `/run` route:
  - `/run/:runId`: `POST` a new run request. The request must have `multipart/form-data` with only one field in the format `input: [string or file]`.
  - `/run/:runId`: `GET` the status for a run. `DELETE` a previous run data.
  